### PR TITLE
Create default issue templates for the org

### DIFF
--- a/ISSUE_TEMPLATE/bug-report.yml
+++ b/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: 🐛 Bug report
+description: Create a report to help us improve
+labels: bug
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Reproduction steps
+      description: Steps to reproduce the behavior
+      value: |
+        1.
+        2.
+        3.
+        ...
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/ISSUE_TEMPLATE/feature-request.yml
+++ b/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,36 @@
+name: 🚀 Feature request
+description: Suggest an idea for this project
+labels: enhancement
+
+body:
+  - type: textarea
+    id: describe-problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: describe-solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: describe-alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
The .github repository can act as a special repo that sets a number
of communtiy default files. One of these defaults are the issue
templates. This change adds templates for creating Bugs and Features.
Of course, any repo may customize their own templates. These files
only have effect if none exists in other repos in this org.

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

Signed-off-by: Eric Brown <browne@vmware.com>