### PR TITLE
Remove 'bash' rendering from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,7 +26,6 @@ body:
         2.
         3.
         ...
-      render: bash
     validations:
       required: true
 


### PR DESCRIPTION
Hi there,

Our team maintains the [SplinterDB open-source project](https://github.com/vmware/splinterdb) which inherits the issue templates from this repo.

The bug-report template has a "reproduction steps" section.  Currently, it has the default-value (hint for contributor) of a Markdown list, but it renders as `bash`.  This makes for awkwardness, especially when a contributor attempts to embed their own code-snippets in that section using Markdown syntax.

Below, I've attached a screenshot of an issue recently created by an outside contributor, who was trying to use the template, that demonstrates the problems.

This PR removes the `bash` rendering, so that the _Reproduction Steps_ text field just renders as Markdown, the same as the other sections. 

----

*Screenshot of an issue-rendering problem that would be fixed by this PR*:

![image](https://user-images.githubusercontent.com/4128521/190002075-f2f9e4d5-7064-4333-9abe-be9a86344309.png)
