### PR TITLE
fix(ci): pass APP_TOKEN to compliance policy verification step

### DIFF
--- a/.github/workflows/required-compliance.yml
+++ b/.github/workflows/required-compliance.yml
@@ -75,6 +75,7 @@ jobs:
           
           # Auth & Context
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           CENTRAL_ORG: ${{ vars.CENTRAL_ORG }}


### PR DESCRIPTION
Summary
Adds APP_TOKEN: ${{ steps.app-token.outputs.token }} to the environment variables of the Verify Compliance step in .github/workflows/required-compliance.yml.

Reason
This ensures policy_selector.py can authenticate using the elevated GitHub App token when performing cross-repository API requests (checking membership, signature verification, painting commit statuses, and posting PR comments).